### PR TITLE
Add `Usage` section in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,59 @@ This package is heavily inspired by the [`secrecy` Rust crate][rust-secrecy]
 
 ## Usage
 
+If one of your types is holding some kind of sensible information it can be easy to accidentally expose that value
 
+For example if you are using a type to hold authentication information
+
+```swift
+struct Authentication {
+  var username: String
+  var token: String
+}
+```
+
+maybe you later are printing debug information to identify problems
+
+```swift
+let auth = Authentication(username: "fake", password: "abc123")
+print(auth)
+```
+
+Now in your log the password will be printed in cleartext
+
+```
+Authentication(username: "fake", password: "abc123")
+``` 
+
+Instead by using `Secret` you can avoid this mistakes. By changing the type definition into
+
+```swift
+struct Authentication {
+  var username: String
+  var token: Secret<String>
+}
+```
+
+The same type of code
+
+```swift
+let auth = Authentication(username: "fake", password: Secret("abc123"))
+print(auth)
+```
+
+Will result in this log
+
+```
+Authentication(username: "fake", password: Secret([REDACTED String]))
+```
+
+Protecting you from accidental mistakes.
+
+If you want to access the underlying value, you can do it by using the `exposeSecret` method
+
+```swift
+auth.token.exposeSecret() // This will expose the underlying `String` 
+```
 
 ## Codable support
 

--- a/Tests/SecrecyTests/SecrecyTests.swift
+++ b/Tests/SecrecyTests/SecrecyTests.swift
@@ -68,6 +68,14 @@ final class SecrecyTests: XCTestCase {
     XCTAssertEqual(secret.username, decodedSecret.username)
     XCTAssertEqual(secret.password.exposeSecret(), decodedSecret.password.exposeSecret())
   }
+
+  func testAutomaticStringConversion() {
+    let fake = FakeCredentials(username: "Test", password: Secret("password"))
+    XCTAssertEqual(
+      "FakeCredentials(username: \"Test\", password: Secret([REDACTED String]))",
+      "\(fake)"
+    )
+  }
 }
 
 private struct FakeCredentials: Codable {


### PR DESCRIPTION
To allow newcomers to have a clear picture on how to use the library, we provide a section in the `README` file that gives an bird's-eye view on the basic usage

Fixes #2 