### PR TITLE
Add basic macOS and Linux CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: "Swift Secrecy CI"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "Package.swift"
+      - "Source/**"
+      - "Tests/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "Package.swift"
+      - "Source/**"
+      - "Tests/**"
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  macOS:
+    strategy:
+      matrix:
+        xcode:
+          - "14.1"
+
+    name: "macOS 12 (Xcode ${{ matrix.xcode }})"
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Run tests
+        run: swift test
+
+  ubuntu:
+    strategy:
+      matrix:
+        swift:
+          - "5.7"
+
+    name: "Ubuntu (Swift ${{ matrix.swift }})"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v3
+      - run: swift test


### PR DESCRIPTION
To ensure an healthy codebase we need to setup a CI system. This PR adds basic GitHub Actions integration by creating a workflow that is run on push or pull request opened to the `main` branch.

Fixes #3 