### PR TITLE
`@Secret` PropertyWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example if you are using a type to hold authentication information
 ```swift
 struct Authentication {
   var username: String
-  var token: String
+  @var token: String
 }
 ```
 
@@ -34,14 +34,14 @@ Instead by using `Secret` you can avoid this mistakes. By changing the type defi
 ```swift
 struct Authentication {
   var username: String
-  var token: Secret<String>
+  @Secret var token: String
 }
 ```
 
 The same type of code
 
 ```swift
-let auth = Authentication(username: "fake", password: Secret("abc123"))
+let auth = Authentication(username: "fake", password: "abc123")
 print(auth)
 ```
 
@@ -53,10 +53,10 @@ Authentication(username: "fake", password: Secret([REDACTED String]))
 
 Protecting you from accidental mistakes.
 
-If you want to access the underlying value, you can do it by using the `exposeSecret` method
+If you want to access the underlying value, you can do it by using the `wrappedValue` property
 
 ```swift
-auth.token.exposeSecret() // This will expose the underlying `String` 
+auth.token.wrappedValue // This will expose the underlying `String` 
 ```
 
 ## Codable support

--- a/Sources/Secrecy/Secret+Codable.swift
+++ b/Sources/Secrecy/Secret+Codable.swift
@@ -14,6 +14,6 @@ extension Secret: Decodable where Wrapped: Decodable {
 extension Secret: Encodable where Wrapped: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-    try container.encode(exposeSecret())
+    try container.encode(wrappedValue)
   }
 }

--- a/Sources/Secrecy/Secret+Literal.swift
+++ b/Sources/Secrecy/Secret+Literal.swift
@@ -1,0 +1,47 @@
+// MARK: - ExpressibleByUnicodeScalarLiteral
+
+extension Secret: ExpressibleByUnicodeScalarLiteral where Wrapped == String {
+  public init(unicodeScalarLiteral value: Wrapped) {
+    self.init(value)
+  }
+}
+
+// MARK: - ExpressibleByExtendedGraphemeClusterLiteral
+
+extension Secret: ExpressibleByExtendedGraphemeClusterLiteral where Wrapped == String {
+  public init(extendedGraphemeClusterLiteral value: Wrapped) {
+    self.init(value)
+  }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension Secret: ExpressibleByStringLiteral where Wrapped == String {
+  public init(stringLiteral value: Wrapped) {
+    self.init(value)
+  }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension Secret: ExpressibleByIntegerLiteral where Wrapped == Int {
+  public init(integerLiteral value: Int) {
+    self.init(value)
+  }
+}
+
+// MARK: - ExpressibleByFloatLiteral
+
+extension Secret: ExpressibleByFloatLiteral where Wrapped == Double {
+  public init(floatLiteral value: Double) {
+    self.init(value)
+  }
+}
+
+// MARK: - ExpressibleByBooleanLiteral
+
+extension Secret: ExpressibleByBooleanLiteral where Wrapped == Bool {
+  public init(booleanLiteral value: Bool) {
+    self.init(value)
+  }
+}

--- a/Sources/Secrecy/Secret+Literal.swift
+++ b/Sources/Secrecy/Secret+Literal.swift
@@ -45,3 +45,40 @@ extension Secret: ExpressibleByBooleanLiteral where Wrapped == Bool {
     self.init(value)
   }
 }
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension Secret: ExpressibleByArrayLiteral where Wrapped: _WrapperForArrayLiteralElements {
+  public init(arrayLiteral elements: Wrapped.ArrayLiteralElement...) {
+    self.init(Wrapped(elements))
+  }
+}
+
+/// A helper protocol used to enable wrapper types to conform to `ExpressibleByArrayLiteral`.
+/// Seen in https://github.com/apollographql/apollo-ios/blob/014660b14262df15f0d2c7b7e973d0a53be27b7e/Sources/ApolloAPI/GraphQLNullable.swift#L188
+/// Used by ``Secret.init(arrayLiteral:)``
+public protocol _WrapperForArrayLiteralElements: ExpressibleByArrayLiteral {
+  init(_ array: [ArrayLiteralElement])
+}
+extension Array: _WrapperForArrayLiteralElements {}
+
+// MARK: - ExpressibleByDictionaryLiteral
+
+extension Secret: ExpressibleByDictionaryLiteral where Wrapped: _WrapperForDictionaryLiteralElements {
+  public init(dictionaryLiteral elements: (Wrapped.Key, Wrapped.Value)...) {
+    self.init(Wrapped(elements))
+  }
+}
+
+/// A helper protocol used to enable wrapper types to conform to `ExpressibleByDictionaryLiteral`.
+/// Seen in https://github.com/apollographql/apollo-ios/blob/014660b14262df15f0d2c7b7e973d0a53be27b7e/Sources/ApolloAPI/GraphQLNullable.swift#L195
+/// Used by ``Secret.init(dictionaryLiteral:)``
+public protocol _WrapperForDictionaryLiteralElements: ExpressibleByDictionaryLiteral {
+  init(_ dictionary: [(Key, Value)])
+}
+
+extension Dictionary: _WrapperForDictionaryLiteralElements {
+  public init(_ elements: [(Key, Value)]) {
+    self.init(uniqueKeysWithValues: elements)
+  }
+}

--- a/Sources/Secrecy/Secret.swift
+++ b/Sources/Secrecy/Secret.swift
@@ -1,19 +1,19 @@
 /// A type that wraps a value which should not be exposed lightly.
+@propertyWrapper
 public struct Secret<Wrapped> {
   /// The value that should be treated with care.
   private let value: Wrapped
+
+  /// The underlying secret that we are trying to keep hidden
+  public var wrappedValue: Wrapped {
+    value
+  }
 
   /// Creates a new secret by wrapping the provided value.
   ///
   /// - Parameter value: The value to keep secret
   public init(_ value: Wrapped) {
     self.value = value
-  }
-
-  /// Explicitly extract the value from the secret, to be able to obtain the stored value.
-  /// - Returns: The raw value of the secret.
-  public func exposeSecret() -> Wrapped {
-    value
   }
 }
 
@@ -32,3 +32,7 @@ extension Secret: CustomDebugStringConvertible {
     "Secret([REDACTED \(Wrapped.self)])"
   }
 }
+
+// MARK: - Sendable
+
+extension Secret: Sendable where Wrapped: Sendable { }

--- a/Tests/SecrecyTests/SecrecyTests.swift
+++ b/Tests/SecrecyTests/SecrecyTests.swift
@@ -88,6 +88,13 @@ final class SecrecyTests: XCTestCase {
       "\(propertyWrapperContainer)"
     )
   }
+
+  func testExpressibleByLiteral() {
+    XCTAssertEqual(("password" as Secret<String>).debugDescription, "Secret([REDACTED String])")
+    XCTAssertEqual((10 as Secret<Int>).debugDescription, "Secret([REDACTED Int])")
+    XCTAssertEqual((10.0 as Secret<Double>).debugDescription, "Secret([REDACTED Double])")
+    XCTAssertEqual((true as Secret<Bool>).debugDescription, "Secret([REDACTED Bool])")
+  }
 }
 
 private struct FakeCredentials: Codable {

--- a/Tests/SecrecyTests/SecrecyTests.swift
+++ b/Tests/SecrecyTests/SecrecyTests.swift
@@ -44,7 +44,7 @@ final class SecrecyTests: XCTestCase {
     let credentials = try JSONDecoder().decode(FakeCredentials.self, from: data)
 
     XCTAssertEqual(credentials.password.debugDescription, "Secret([REDACTED String])")
-    XCTAssertEqual(credentials.password.exposeSecret(), "very_secret")
+    XCTAssertEqual(credentials.password.wrappedValue, "very_secret")
   }
 
   func testEncoding() throws {
@@ -66,14 +66,26 @@ final class SecrecyTests: XCTestCase {
     let decodedSecret = try JSONDecoder().decode(FakeCredentials.self, from: data)
 
     XCTAssertEqual(secret.username, decodedSecret.username)
-    XCTAssertEqual(secret.password.exposeSecret(), decodedSecret.password.exposeSecret())
+    XCTAssertEqual(secret.password.wrappedValue, decodedSecret.password.wrappedValue)
   }
 
   func testAutomaticStringConversion() {
-    let fake = FakeCredentials(username: "Test", password: Secret("password"))
+    let fake = FakeCredentials(username: "Test", password: "password")
     XCTAssertEqual(
       "FakeCredentials(username: \"Test\", password: Secret([REDACTED String]))",
       "\(fake)"
+    )
+  }
+
+  func testPropertyWrapper() {
+    let propertyWrapperContainer = PropertyWrapperTest(
+      username: "Test",
+      password: "password"
+    )
+
+    XCTAssertEqual(
+      "PropertyWrapperTest(username: \"Test\", _password: Secret([REDACTED String]))",
+      "\(propertyWrapperContainer)"
     )
   }
 }
@@ -81,4 +93,9 @@ final class SecrecyTests: XCTestCase {
 private struct FakeCredentials: Codable {
   var username: String
   var password: Secret<String>
+}
+
+private struct PropertyWrapperTest {
+  var username: String
+  @Secret var password: String
 }

--- a/Tests/SecrecyTests/SecrecyTests.swift
+++ b/Tests/SecrecyTests/SecrecyTests.swift
@@ -94,6 +94,14 @@ final class SecrecyTests: XCTestCase {
     XCTAssertEqual((10 as Secret<Int>).debugDescription, "Secret([REDACTED Int])")
     XCTAssertEqual((10.0 as Secret<Double>).debugDescription, "Secret([REDACTED Double])")
     XCTAssertEqual((true as Secret<Bool>).debugDescription, "Secret([REDACTED Bool])")
+    XCTAssertEqual(
+      (["password", "token"] as Secret<[String]>).debugDescription,
+    "Secret([REDACTED Array<String>])"
+    )
+    XCTAssertEqual(
+      (["username": 1, "password": 2] as Secret<[String: Int]>).debugDescription,
+      "Secret([REDACTED Dictionary<String, Int>])"
+    )
   }
 }
 


### PR DESCRIPTION
The `Secret` type at the moment is a little clumsy to use. By converting the type to be a property wrapper we can have better ergonomics (removing the `exposeSecret` method and using the `wrappedValue`).
An additional improvement to ergonomics is the adoption of the `ExpressibleBy...` protocols

Fixes #5 